### PR TITLE
メッシュ作成時バグ修正

### DIFF
--- a/src/tm/hybrid/mesh.js
+++ b/src/tm/hybrid/mesh.js
@@ -26,9 +26,9 @@
                     } else if (asset instanceof tm.asset.Vox) {
                         this.superInit(asset.mesh.clone());
                     } else if (asset instanceof tm.asset.MQO) {
-                        this.superInit(asset.model.meshes[0]);
+                        this.superInit(asset.model.meshes[0].clone());
                         for (var i = 1; i < asset.model.meshes.length; i++) {
-                            tm.hybrid.Mesh(asset.model.meshes[i]).addChildTo(this);
+                            tm.hybrid.Mesh(asset.model.meshes[i].clone()).addChildTo(this);
                         }
                     }
                 } else {


### PR DESCRIPTION
MQOオブジェクトをtm.hybrid.Meshで使用する際に、cloneするのを忘れてましたので修正しました。
よろしくお願いします。
